### PR TITLE
add AWS tags

### DIFF
--- a/rhel7/nifi-generic.tf
+++ b/rhel7/nifi-generic.tf
@@ -1,127 +1,135 @@
 variable "aws_region" {
-  type                     = string
+  type = string
 }
 
 variable "aws_profile" {
-  type                     = string
+  type = string
+}
+
+variable "aws_default_tags" {
+  type = map(string)
 }
 
 variable "vpc_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "pubnet1_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "prinet1_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "pubnet2_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "prinet2_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "pubnet3_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "prinet3_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "mgmt_cidrs" {
-  type                     = list
-  description              = "Management CIDRs allowed to reach web_port"
+  type        = list(any)
+  description = "Management CIDRs allowed to reach web_port"
 }
 
 variable "client_cidrs" {
-  type                     = list
-  description              = "Client CIDRs allowed to reach service_port(s)"
+  type        = list(any)
+  description = "Client CIDRs allowed to reach service_port(s)"
 }
 
 variable "instance_type" {
-  type                     = string
-  description              = "The type of EC2 instance to deploy"
+  type        = string
+  description = "The type of EC2 instance to deploy"
 }
 
 variable "instance_key" {
-  type                     = string
-  description              = "A public key for SSH access to instance(s)"
+  type        = string
+  description = "A public key for SSH access to instance(s)"
 }
 
 variable "instance_vol_size" {
-  type                     = number
-  description              = "The volume size of the instances' root block device"
+  type        = number
+  description = "The volume size of the instances' root block device"
 }
 
 variable "kms_manager" {
-  type                     = string
-  description              = "An IAM user for management of KMS key"
+  type        = string
+  description = "An IAM user for management of KMS key"
 }
 
 variable "nifi_version" {
-  type                     = string
-  description              = "The version of Apache NiFi, e.g. 1.11.4"
+  type        = string
+  description = "The version of Apache NiFi, e.g. 1.11.4"
 }
 
 variable "zk_version" {
-  type                     = string
-  description              = "The version of Apache Zookeeper, e.g. 3.6.1"
+  type        = string
+  description = "The version of Apache Zookeeper, e.g. 3.6.1"
 }
 
 variable "enable_zk1" {
-  type                     = number
-  description              = "Whether to enable zk1 (1) or not (0)"
+  type        = number
+  description = "Whether to enable zk1 (1) or not (0)"
 }
 
 variable "enable_zk2" {
-  type                     = number
-  description              = "Whether to enable zk2 (1) or not (0)"
+  type        = number
+  description = "Whether to enable zk2 (1) or not (0)"
 }
 
 variable "enable_zk3" {
-  type                     = number
-  description              = "Whether to enable zk3 (1) or not (0)"
+  type        = number
+  description = "Whether to enable zk3 (1) or not (0)"
 }
 
 variable "minimum_node_count" {
-  type                     = number
-  description              = "The minimum number of non-zookeeper NiFi nodes in the Autoscaling Group"
+  type        = number
+  description = "The minimum number of non-zookeeper NiFi nodes in the Autoscaling Group"
 }
 
 variable "maximum_node_count" {
-  type                     = number
-  description              = "The maximum number of non-zookeeper NiFi nodes in the Autoscaling Group"
+  type        = number
+  description = "The maximum number of non-zookeeper NiFi nodes in the Autoscaling Group"
 }
 
 variable "name_prefix" {
-  type                     = string
-  description              = "A friendly name prefix for the AMI and EC2 instances, e.g. 'tf-nifi' or 'dev'"
+  type        = string
+  description = "A friendly name prefix for the AMI and EC2 instances, e.g. 'tf-nifi' or 'dev'"
 }
 
 variable "vendor_ami_account_number" {
-  type                     = string
-  description              = "The account number of the vendor supplying the base AMI"
+  type        = string
+  description = "The account number of the vendor supplying the base AMI"
 }
 
 variable "vendor_ami_name_string" {
-  type                     = string
-  description              = "The search string for the name of the AMI from the AMI Vendor"
+  type        = string
+  description = "The search string for the name of the AMI from the AMI Vendor"
 }
 
 provider "aws" {
-  region                   = var.aws_region
-  profile                  = var.aws_profile
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  default_tags {
+    tags = var.aws_default_tags
+  }
 }
 
 # region azs
 data "aws_availability_zones" "tf-nifi-azs" {
-  state                    = "available"
+  state = "available"
 }
 
 # account id
@@ -130,7 +138,7 @@ data "aws_caller_identity" "tf-nifi-aws-account" {
 
 # kms cmk manager - granted read access to KMS CMKs
 data "aws_iam_user" "tf-nifi-kmsmanager" {
-  user_name               = var.kms_manager
+  user_name = var.kms_manager
 }
 
 # aws, gov, or cn
@@ -139,54 +147,54 @@ data "aws_partition" "tf-nifi-aws-partition" {
 
 # random string as suffix
 resource "random_string" "tf-nifi-random" {
-  length                            = 5
-  upper                             = false
-  special                           = false
+  length  = 5
+  upper   = false
+  special = false
 }
 
 variable "zk_url" {
-  type                   = string
+  type = string
 }
 
 variable "nifi_url" {
-  type                   = string
+  type = string
 }
 
 variable "toolkit_url" {
-  type                   = string
+  type = string
 }
 
 variable "tcp_service_ports" {
-  type                   = list
-  default                = []
+  type    = list(any)
+  default = []
 }
 
 variable "udp_service_ports" {
-  type                   = list
-  default                = []
+  type    = list(any)
+  default = []
 }
 
 variable "tcpudp_service_ports" {
-  type                   = list
-  default                = []
+  type    = list(any)
+  default = []
 }
 
 variable "web_port" {
-  type                   = number
-  default                = 2170
+  type    = number
+  default = 2170
 }
 
 variable "log_retention_days" {
-  type                   = number
-  default                = 30
+  type    = number
+  default = 30
 }
 
 variable "health_check_unit" {
-  type                   = string
-  default                = "minutes"
+  type    = string
+  default = "minutes"
 }
 
 variable "health_check_count" {
-  type                   = string
-  default                = "5"
+  type    = string
+  default = "5"
 }

--- a/rhel7/nifi.tfvars
+++ b/rhel7/nifi.tfvars
@@ -1,6 +1,12 @@
 # aws profile (e.g. from aws configure, usually "default")
 aws_profile = "default"
-aws_region = "us-east-1"
+aws_region  = "us-east-1"
+
+aws_default_tags = {
+  Environment = "Your-Env-Here"
+  Owner       = "Your-Team-Here"
+  Project     = "Your-Project-Here"
+}
 
 # existing aws iam user granted access to the kms key (for browsing KMS encrypted services like S3 or SNS).
 kms_manager = "some_iam_user"
@@ -15,8 +21,8 @@ client_cidrs = []
 web_port = 2170
 
 # service ports for traffic inbound via service NLB
-tcp_service_ports = [2200, 2201]
-udp_service_ports = []
+tcp_service_ports    = [2200, 2201]
+udp_service_ports    = []
 tcpudp_service_ports = []
 
 # inter-cluster communication occurs on ports web_port and 2171 through 2176
@@ -45,26 +51,26 @@ name_prefix = "nifi"
 
 # the vendor supplying the AMI and the AMI name - default is official RHEL7
 vendor_ami_account_number = "309956199498"
-vendor_ami_name_string = "RHEL-7.*_HVM_GA-20*-x86_64-0-Hourly2-GP2"
+vendor_ami_name_string    = "RHEL-7.*_HVM_GA-20*-x86_64-0-Hourly2-GP2"
 
 # days to retain logs in cloudwatch
 log_retention_days = 30
 
 # health check frequency
-health_check_unit = "minutes"
+health_check_unit  = "minutes"
 health_check_count = 5
 
 # nifi/nifi-toolkit and zookeeper versions downloaded from urls below
 nifi_version = "1.13.2"
-zk_version = "3.7.0"
+zk_version   = "3.7.0"
 
 # urls for a lambda function to fetch zookeeper, nifi, and nifi toolkit and put to s3
-zk_url = "https://apache.osuosl.org/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0-bin.tar.gz"
-nifi_url = "https://apache.osuosl.org/nifi/1.13.2/nifi-1.13.2-bin.tar.gz"
+zk_url      = "https://apache.osuosl.org/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0-bin.tar.gz"
+nifi_url    = "https://apache.osuosl.org/nifi/1.13.2/nifi-1.13.2-bin.tar.gz"
 toolkit_url = "https://apache.osuosl.org/nifi/1.13.2/nifi-toolkit-1.13.2-bin.tar.gz"
 
 # vpc specific vars, modify these values if there would be overlap with existing resources.
-vpc_cidr = "10.10.10.0/24"
+vpc_cidr     = "10.10.10.0/24"
 pubnet1_cidr = "10.10.10.0/28"
 pubnet2_cidr = "10.10.10.16/28"
 pubnet3_cidr = "10.10.10.32/28"

--- a/ubuntu/nifi-generic.tf
+++ b/ubuntu/nifi-generic.tf
@@ -1,127 +1,135 @@
 variable "aws_region" {
-  type                     = string
+  type = string
 }
 
 variable "aws_profile" {
-  type                     = string
+  type = string
+}
+
+variable "aws_default_tags" {
+  type = map(string)
 }
 
 variable "vpc_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "pubnet1_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "prinet1_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "pubnet2_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "prinet2_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "pubnet3_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "prinet3_cidr" {
-  type                     = string
+  type = string
 }
 
 variable "mgmt_cidrs" {
-  type                     = list
-  description              = "Management CIDRs allowed to reach web_port"
+  type        = list(any)
+  description = "Management CIDRs allowed to reach web_port"
 }
 
 variable "client_cidrs" {
-  type                     = list
-  description              = "Client CIDRs allowed to reach service_port(s)"
+  type        = list(any)
+  description = "Client CIDRs allowed to reach service_port(s)"
 }
 
 variable "instance_type" {
-  type                     = string
-  description              = "The type of EC2 instance to deploy"
+  type        = string
+  description = "The type of EC2 instance to deploy"
 }
 
 variable "instance_key" {
-  type                     = string
-  description              = "A public key for SSH access to instance(s)"
+  type        = string
+  description = "A public key for SSH access to instance(s)"
 }
 
 variable "instance_vol_size" {
-  type                     = number
-  description              = "The volume size of the instances' root block device"
+  type        = number
+  description = "The volume size of the instances' root block device"
 }
 
 variable "kms_manager" {
-  type                     = string
-  description              = "An IAM user for management of KMS key"
+  type        = string
+  description = "An IAM user for management of KMS key"
 }
 
 variable "nifi_version" {
-  type                     = string
-  description              = "The version of Apache NiFi, e.g. 1.11.4"
+  type        = string
+  description = "The version of Apache NiFi, e.g. 1.11.4"
 }
 
 variable "zk_version" {
-  type                     = string
-  description              = "The version of Apache Zookeeper, e.g. 3.6.1"
+  type        = string
+  description = "The version of Apache Zookeeper, e.g. 3.6.1"
 }
 
 variable "enable_zk1" {
-  type                     = number
-  description              = "Whether to enable zk1 (1) or not (0)"
+  type        = number
+  description = "Whether to enable zk1 (1) or not (0)"
 }
 
 variable "enable_zk2" {
-  type                     = number
-  description              = "Whether to enable zk2 (1) or not (0)"
+  type        = number
+  description = "Whether to enable zk2 (1) or not (0)"
 }
 
 variable "enable_zk3" {
-  type                     = number
-  description              = "Whether to enable zk3 (1) or not (0)"
+  type        = number
+  description = "Whether to enable zk3 (1) or not (0)"
 }
 
 variable "minimum_node_count" {
-  type                     = number
-  description              = "The minimum number of non-zookeeper NiFi nodes in the Autoscaling Group"
+  type        = number
+  description = "The minimum number of non-zookeeper NiFi nodes in the Autoscaling Group"
 }
 
 variable "maximum_node_count" {
-  type                     = number
-  description              = "The maximum number of non-zookeeper NiFi nodes in the Autoscaling Group"
+  type        = number
+  description = "The maximum number of non-zookeeper NiFi nodes in the Autoscaling Group"
 }
 
 variable "name_prefix" {
-  type                     = string
-  description              = "A friendly name prefix for the AMI and EC2 instances, e.g. 'tf-nifi' or 'dev'"
+  type        = string
+  description = "A friendly name prefix for the AMI and EC2 instances, e.g. 'tf-nifi' or 'dev'"
 }
 
 variable "vendor_ami_account_number" {
-  type                     = string
-  description              = "The account number of the vendor supplying the base AMI"
+  type        = string
+  description = "The account number of the vendor supplying the base AMI"
 }
 
 variable "vendor_ami_name_string" {
-  type                     = string
-  description              = "The search string for the name of the AMI from the AMI Vendor"
+  type        = string
+  description = "The search string for the name of the AMI from the AMI Vendor"
 }
 
 provider "aws" {
-  region                   = var.aws_region
-  profile                  = var.aws_profile
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  default_tags {
+    tags = var.aws_default_tags
+  }
 }
 
 # region azs
 data "aws_availability_zones" "tf-nifi-azs" {
-  state                    = "available"
+  state = "available"
 }
 
 # account id
@@ -130,7 +138,7 @@ data "aws_caller_identity" "tf-nifi-aws-account" {
 
 # kms cmk manager - granted read access to KMS CMKs
 data "aws_iam_user" "tf-nifi-kmsmanager" {
-  user_name               = var.kms_manager
+  user_name = var.kms_manager
 }
 
 # aws, gov, or cn
@@ -139,54 +147,54 @@ data "aws_partition" "tf-nifi-aws-partition" {
 
 # random string as suffix
 resource "random_string" "tf-nifi-random" {
-  length                            = 5
-  upper                             = false
-  special                           = false
+  length  = 5
+  upper   = false
+  special = false
 }
 
 variable "zk_url" {
-  type                   = string
+  type = string
 }
 
 variable "nifi_url" {
-  type                   = string
+  type = string
 }
 
 variable "toolkit_url" {
-  type                   = string
+  type = string
 }
 
 variable "tcp_service_ports" {
-  type                   = list
-  default                = []
+  type    = list(any)
+  default = []
 }
 
 variable "udp_service_ports" {
-  type                   = list
-  default                = []
+  type    = list(any)
+  default = []
 }
 
 variable "tcpudp_service_ports" {
-  type                   = list
-  default                = []
+  type    = list(any)
+  default = []
 }
 
 variable "web_port" {
-  type                   = number
-  default                = 2170
+  type    = number
+  default = 2170
 }
 
 variable "log_retention_days" {
-  type                   = number
-  default                = 30
+  type    = number
+  default = 30
 }
 
 variable "health_check_unit" {
-  type                   = string
-  default                = "minutes"
+  type    = string
+  default = "minutes"
 }
 
 variable "health_check_count" {
-  type                   = string
-  default                = "5"
+  type    = string
+  default = "5"
 }

--- a/ubuntu/nifi.tfvars
+++ b/ubuntu/nifi.tfvars
@@ -1,6 +1,12 @@
 # aws profile (e.g. from aws configure, usually "default")
 aws_profile = "default"
-aws_region = "us-east-1"
+aws_region  = "us-east-1"
+
+aws_default_tags = {
+  Environment = "Your-Env-Here"
+  Owner       = "Your-Team-Here"
+  Project     = "Your-Project-Here"
+}
 
 # existing aws iam user granted access to the kms key (for browsing KMS encrypted services like S3 or SNS).
 kms_manager = "some_iam_user"
@@ -15,8 +21,8 @@ client_cidrs = []
 web_port = 2170
 
 # service ports for traffic inbound via service NLB
-tcp_service_ports = [2200, 2201]
-udp_service_ports = []
+tcp_service_ports    = [2200, 2201]
+udp_service_ports    = []
 tcpudp_service_ports = []
 
 # inter-cluster communication occurs on ports web_port and 2171 through 2176
@@ -45,26 +51,26 @@ name_prefix = "nifi"
 
 # the vendor supplying the AMI and the AMI name - default is official Ubuntu 20.04
 vendor_ami_account_number = "099720109477"
-vendor_ami_name_string = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210415"
+vendor_ami_name_string    = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210415"
 
 # days to retain logs in cloudwatch
 log_retention_days = 30
 
 # health check frequency
-health_check_unit = "minutes"
+health_check_unit  = "minutes"
 health_check_count = 5
 
 # nifi/nifi-toolkit and zookeeper versions downloaded from urls below
 nifi_version = "1.13.2"
-zk_version = "3.7.0"
+zk_version   = "3.7.0"
 
 # urls for a lambda function to fetch zookeeper, nifi, and nifi toolkit and put to s3
-zk_url = "https://apache.osuosl.org/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0-bin.tar.gz"
-nifi_url = "https://apache.osuosl.org/nifi/1.13.2/nifi-1.13.2-bin.tar.gz"
+zk_url      = "https://apache.osuosl.org/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0-bin.tar.gz"
+nifi_url    = "https://apache.osuosl.org/nifi/1.13.2/nifi-1.13.2-bin.tar.gz"
 toolkit_url = "https://apache.osuosl.org/nifi/1.13.2/nifi-toolkit-1.13.2-bin.tar.gz"
 
 # vpc specific vars, modify these values if there would be overlap with existing resources.
-vpc_cidr = "10.10.10.0/24"
+vpc_cidr     = "10.10.10.0/24"
 pubnet1_cidr = "10.10.10.0/28"
 pubnet2_cidr = "10.10.10.16/28"
 pubnet3_cidr = "10.10.10.32/28"


### PR DESCRIPTION
Dearest @chadgeary  .. Ive used the AWS Provider default tags to auto-magically tags all resources .. 

It appears your editor formatter is different that `terraform fmt` and it makes this MR look huge .. basic changes were

add new variable:

```
variable "aws_default_tags" {
  type = map(string)
}

aws_default_tags = {
     Environment = "Your-Env-Here"
     Owner       = "Your-Team-Here"
     Project     = "Your-Project-Here"
}
```

add tag block to provider 

```
 default_tags {
    tags = var.aws_default_tags
 }
```