### PR TITLE
zks-on-ec2: refactor certs, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 *.terraform*.tfstate*.lock*.
 *pvars.*
 *.swp
-*.zip
 **/zks-on-ec2/nifi-lambda-certs/
 **/zks-on-fargate/nifi-lambda-certs/

--- a/README.md
+++ b/README.md
@@ -126,10 +126,6 @@ Deploy
 # In powershell's WSL window, change to the project's aws directory
 cd ~/nifi/zks-on-ec2/
 
-# Copy nifi-lambda-certs.py and add the cryptography module to nifi-lambda-certs/
-mkdir nifi-lambda-certs && cp nifi-lambda-certs.py nifi-lambda-certs/
-pip3 install --upgrade --target ./nifi-lambda-certs/ cryptography
-
 # Initialize terraform and apply the terraform state
 terraform init
 terraform apply -var-file="nifi.tfvars"

--- a/zks-on-ec2/nifi-ami.tf
+++ b/zks-on-ec2/nifi-ami.tf
@@ -18,16 +18,9 @@ data "aws_ami" "tf-nifi-vendor-ami-latest" {
     name   = "root-device-type"
     values = ["ebs"]
   }
-}
-
-resource "aws_ami_copy" "tf-nifi-encrypted-ami" {
-  name              = "${var.name_prefix}-encrypted-ami-${random_string.tf-nifi-random.result}"
-  description       = "KMS CMK-encrypted AMI of latest official vendor AMI"
-  source_ami_id     = data.aws_ami.tf-nifi-vendor-ami-latest.id
-  source_ami_region = var.aws_region
-  encrypted         = true
-  kms_key_id        = aws_kms_key.tf-nifi-kmscmk-ec2.arn
-  tags = {
-    Name = "${var.name_prefix}-encrypted-ami-${random_string.tf-nifi-random.result}"
+  lifecycle {
+    ignore_changes = [
+      id
+    ]
   }
 }

--- a/zks-on-ec2/nifi-ami.tf
+++ b/zks-on-ec2/nifi-ami.tf
@@ -18,9 +18,4 @@ data "aws_ami" "tf-nifi-vendor-ami-latest" {
     name   = "root-device-type"
     values = ["ebs"]
   }
-  lifecycle {
-    ignore_changes = [
-      id
-    ]
-  }
 }

--- a/zks-on-ec2/nifi-iam-lambda-health.tf
+++ b/zks-on-ec2/nifi-iam-lambda-health.tf
@@ -1,4 +1,4 @@
-data "aws_iam_policy" "tf-nifi-iam-policy-lambda-certs-1" {
+data "aws_iam_policy" "tf-nifi-iam-policy-lambda-health-1" {
   arn = "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:iam::aws:policy/AmazonSSMFullAccess"
 }
 

--- a/zks-on-ec2/nifi-iam-lambda-health.tf
+++ b/zks-on-ec2/nifi-iam-lambda-health.tf
@@ -1,8 +1,12 @@
-data "aws_iam_policy" "tf-nifi-iam-policy-lambda-health-1" {
+data "aws_iam_policy" "tf-nifi-iam-policy-lambda-certs-1" {
+  arn = "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:iam::aws:policy/AmazonSSMFullAccess"
+}
+
+data "aws_iam_policy" "tf-nifi-iam-policy-lambda-health-2" {
   arn = "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
-resource "aws_iam_policy" "tf-nifi-iam-policy-lambda-health-2" {
+resource "aws_iam_policy" "tf-nifi-iam-policy-lambda-health-3" {
   name        = "${var.name_prefix}-iam-policy-lambda-health-${random_string.tf-nifi-random.result}"
   path        = "/"
   description = "Provides lambda EC2 and InstanceHealth permission"
@@ -21,6 +25,14 @@ resource "aws_iam_policy" "tf-nifi-iam-policy-lambda-health-2" {
         "kms:DescribeKey"
       ],
       "Resource": ["${aws_kms_key.tf-nifi-kmscmk-lambda.arn}"]
+    },
+    {
+      "Sid": "SSMCMK",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": ["${aws_kms_key.tf-nifi-kmscmk-ssm.arn}"]
     },
     {
       "Sid": "LambdaEC2",
@@ -103,5 +115,10 @@ resource "aws_iam_role_policy_attachment" "tf-nifi-iam-attach-health-lambda-1" {
 
 resource "aws_iam_role_policy_attachment" "tf-nifi-iam-attach-health-lambda-2" {
   role       = aws_iam_role.tf-nifi-iam-role-lambda-health.name
-  policy_arn = aws_iam_policy.tf-nifi-iam-policy-lambda-health-2.arn
+  policy_arn = data.aws_iam_policy.tf-nifi-iam-policy-lambda-health-2.arn
+}
+
+resource "aws_iam_role_policy_attachment" "tf-nifi-iam-attach-health-lambda-3" {
+  role       = aws_iam_role.tf-nifi-iam-role-lambda-health.name
+  policy_arn = aws_iam_policy.tf-nifi-iam-policy-lambda-health-3.arn
 }

--- a/zks-on-ec2/nifi-kms-ssm.tf
+++ b/zks-on-ec2/nifi-kms-ssm.tf
@@ -53,6 +53,23 @@ resource "aws_kms_key" "tf-nifi-kmscmk-ssm" {
           "kms:ViaService": "ssm.${var.aws_region}.amazonaws.com"
         }
       }
+    },
+    {
+      "Sid": "Allow access through Lambda health",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.tf-nifi-iam-role-lambda-health.arn}"
+      },
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:CallerAccount": "${data.aws_caller_identity.tf-nifi-aws-account.account_id}",
+          "kms:ViaService": "ssm.${var.aws_region}.amazonaws.com"
+        }
+      }
     }
   ]
 }

--- a/zks-on-ec2/nifi-lambda-certs.py
+++ b/zks-on-ec2/nifi-lambda-certs.py
@@ -204,7 +204,7 @@ def lambda_handler(event, context):
     # Check for certificates in S3, because this only runs if they don't exist
     s3 = boto3.resource("s3")
     s3_object = list(
-        s3.Bucket(os.environ["BUCKET"]).objects.filter(Prefix="nifi/certificates/")
+        s3.Bucket(os.environ["BUCKET"]).objects.filter(Prefix="nifi/certificates/ca/")
     )
     if len(s3_object) >= 2:
         print("Certificates found, skipping.")
@@ -325,24 +325,14 @@ def lambda_handler(event, context):
 
             # UPLOAD
             files = {
-                "nifi/certificates/ca/ca.pem": io.BytesIO(
-                    identities["ca"].get("public_bytes")
-                ),
-                "nifi/certificates/ca/ca.key": io.BytesIO(
-                    identities["ca"].get("private_bytes")
-                ),
-                "nifi/certificates/admin/admin_cert.pem": io.BytesIO(
-                    identities["admin"].get("public_bytes")
-                ),
-                "nifi/certificates/admin/private_key.key": io.BytesIO(
-                    identities["admin"].get("private_bytes")
-                ),
-                "nifi/certificates/admin/keystore.p12": io.BytesIO(
-                    identities["admin"].get("identity_certstore")
-                ),
+                "nifi/certificates/ca/ca.pem": "/tmp/nifi/certificates/nifica/nifica.pem",
+                "nifi/certificates/ca/ca.key": "/tmp/nifi/certificates/nifica/nifica.key",
+                "nifi/certificates/admin/admin_cert.pem": "/tmp/nifi/certificates/admin/admin.pem",
+                "nifi/certificates/admin/private_key.key": "/tmp/nifi/certificates/admin/admin.key",
+                "nifi/certificates/admin/keystore.p12": "/tmp/nifi/certificates/admin/admin.p12",
             }
         for key in files:
-            s3.meta.client.upload_fileobj(
+            s3.meta.client.upload_file(
                 files[key],
                 os.environ["BUCKET"],
                 key,

--- a/zks-on-ec2/nifi-lambda-certs.py
+++ b/zks-on-ec2/nifi-lambda-certs.py
@@ -10,124 +10,347 @@ import io
 import json
 import os
 
+# A private key
+def gen_privatekey():
+    privatekey = rsa.generate_private_key(
+        public_exponent=65537, key_size=4096, backend=backends.default_backend()
+    )
+    return privatekey
+
+
+# PEM encoded PKCS8 + encryption of privatekey using secret
+def gen_privatebytes(identity_privatekey, secret):
+    privatebytes = identity_privatekey.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.BestAvailableEncryption(secret),
+    )
+    return privatebytes
+
+
+# A public key from the private key
+def gen_publickey(identity_privatekey):
+    identity_publickey = identity_privatekey.public_key()
+    return identity_publickey
+
+
+# PEM encoded public key
+def gen_publicbytes(identity_publickey):
+    publicbytes = identity_publickey.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return publicbytes
+
+
+# Create a CA-signed cert using an identity's context
+def gen_x509(
+    platform_name,
+    identity_name,
+    identity_publickey,
+    ca_name,
+    ca_privatekey,
+    is_ca,
+    is_client,
+    is_server,
+):
+    builder = x509.CertificateBuilder()
+
+    # CAs do not get OU
+    if is_ca:
+        builder = builder.subject_name(
+            x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, identity_name)])
+        )
+    else:
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, platform_name),
+                    x509.NameAttribute(NameOID.COMMON_NAME, identity_name),
+                ]
+            )
+        )
+    builder = builder.issuer_name(
+        x509.Name(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, ca_name),
+            ]
+        )
+    )
+    builder = builder.not_valid_before(now)
+    builder = builder.not_valid_after(expire_date)
+    builder = builder.serial_number(x509.random_serial_number())
+    builder = builder.public_key(identity_publickey)
+
+    # CAs get BasicConstraints
+    if is_ca:
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True
+        )
+
+    # Client+Servers get KeyUsage, ExtendedKeyUsage CLIENT_AUTH + SERVER_AUTH, and SAN DNSName
+    if is_client and is_server:
+        builder = builder.add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=True,
+                key_agreement=True,
+                key_cert_sign=True,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        builder = builder.add_extension(
+            x509.ExtendedKeyUsage(
+                [
+                    x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
+                    x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
+                ]
+            ),
+            critical=True,
+        )
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName(
+                [x509.DNSName(identity_name), x509.DNSName("localhost")]
+            ),
+            critical=False,
+        )
+
+    # Clients get KeyUsage, ExtendedKeyUsage CLIENT_AUTH
+    if is_client and not is_server:
+        builder = builder.add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=True,
+                key_agreement=True,
+                key_cert_sign=True,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        builder = builder.add_extension(
+            x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH]),
+            critical=True,
+        )
+
+    certificate = builder.sign(
+        private_key=ca_privatekey,
+        algorithm=hashes.SHA256(),
+        backend=backends.default_backend(),
+    )
+    return certificate
+
+
+# Write the certificate to S3
+def upload_certificate_to_s3(identity_certificate_path):
+    with open(identity_certificate_path, "rb") as certificate_path:
+        certificate = x509.load_pem_x509_certificate(certificate_path.read())
+    return certificate
+
+
+# Create a certificate store
+def gen_certificatestore(
+    identity_name, identity_privatekey, identity_certificate, ca_certificate, secret
+):
+    certificatestore = pkcs12.serialize_key_and_certificates(
+        str.encode(identity_name),
+        identity_privatekey,
+        identity_certificate,
+        [ca_certificate],
+        serialization.BestAvailableEncryption(secret),
+    )
+    return certificatestore
+
+
 def lambda_handler(event, context):
 
-    now = datetime.datetime.now()
-    expire_date = now + datetime.timedelta(days=3650)
+    # Identities at bootstrap requiring certificates
+    identities = {
+        "ca": {"name": "nifica", "is_ca": True, "is_client": False, "is_server": False},
+        "admin": {
+            "name": "admin",
+            "is_ca": False,
+            "is_client": True,
+            "is_server": False,
+        },
+        "node1": {
+            "name": "node1",
+            "is_ca": False,
+            "is_client": True,
+            "is_server": True,
+        },
+        "node2": {
+            "name": "node2",
+            "is_ca": False,
+            "is_client": True,
+            "is_server": True,
+        },
+        "node3": {
+            "name": "node2",
+            "is_ca": False,
+            "is_client": True,
+            "is_server": True,
+        },
+    }
 
-    # PARAMETER
-    ssm = boto3.client('ssm', region_name=os.environ['REGION'])
-    nifi_secret = ssm.get_parameter(
-        Name=os.environ['PREFIX']+'-nifi-secret-'+os.environ['SUFFIX'],
-        WithDecryption=True
+    # Check for certificates in S3, because this only runs if they don't exist
+    s3 = boto3.resource("s3")
+    s3_object = list(
+        s3.Bucket(os.environ["BUCKET"]).objects.filter(Prefix="nifi/certificates/")
     )
-
-    s3 = boto3.resource('s3')
-
-    s3_object = list(s3.Bucket(os.environ['BUCKET']).objects.filter(Prefix='nifi/certificates/'))
-    if len(s3_object) == 5:
-        print('Certificates found, skipping.')
+    if len(s3_object) >= 2:
+        print("Certificates found, skipping.")
     else:
-        print('Certificates not found, generating.')
+        print("Certificates not found, generating.")
 
-        # Valid dates
+        # 5 o'clock somewhere, setting an absurdly long certificate lifetime
+        global now
         now = datetime.datetime.now()
+        global expire_date
         expire_date = now + datetime.timedelta(days=3650)
-
-        # CA
-        ca_private_key = rsa.generate_private_key(
-            public_exponent=65537,
-            key_size=2048,
-            backend=backends.default_backend()
+        print(
+            "Generated certificates will be valid between "
+            + now.strftime("%Y-%m-%d %H:%M:%S %Z")
+            + " and "
+            + expire_date.strftime("%Y-%m-%d %H:%M:%S %Z")
         )
 
-        ca_public_key = ca_private_key.public_key()
-        builder = x509.CertificateBuilder()
-        builder = builder.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, u"NIFICA"),
-        ]))
-        builder = builder.issuer_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, u"NIFICA"),
-        ]))
-        builder = builder.not_valid_before(now)
-        builder = builder.not_valid_after(expire_date)
-        builder = builder.serial_number(x509.random_serial_number())
-        builder = builder.public_key(ca_public_key)
-        builder = builder.add_extension(
-            x509.BasicConstraints(ca=True, path_length=None),
-            critical=True)
-        ca_certificate = builder.sign(
-            private_key=ca_private_key, algorithm=hashes.SHA256(), backend=backends.default_backend()
+        # Get nifi-secret for encryption
+        ssm = boto3.client("ssm", region_name=os.environ["REGION"])
+        ssm_secret = ssm.get_parameter(
+            Name=os.environ["PREFIX"] + "-nifi-secret-" + os.environ["SUFFIX"],
+            WithDecryption=True,
         )
-        ca_private_bytes = ca_private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.BestAvailableEncryption(str.encode(nifi_secret['Parameter']['Value'])))
-        ca_public_bytes = ca_certificate.public_bytes(
-            encoding=serialization.Encoding.PEM)
+        secret = str.encode(ssm_secret["Parameter"]["Value"])
 
-        # ADMIN
-        admin_private_key = rsa.generate_private_key(
-            public_exponent=65537,
-            key_size=2048,
-            backend=backends.default_backend()
-        )
+        # Loop over identities to create a private key, public key, certificate, and certificate store
+        for identity in identities:
 
-        admin_public_key = admin_private_key.public_key()
-        builder2 = x509.CertificateBuilder()
-        builder2 = builder2.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, u"NIFI"),
-            x509.NameAttribute(NameOID.COMMON_NAME, u"admin")
-        ]))
-        builder2 = builder2.issuer_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, u"NIFICA"),
-        ]))
-        builder2 = builder2.not_valid_before(now)
-        builder2 = builder2.not_valid_after(expire_date)
-        builder2 = builder2.serial_number(x509.random_serial_number())
-        builder2 = builder2.public_key(admin_public_key)
-        builder2 = builder2.add_extension(
-            x509.KeyUsage(digital_signature=True, content_commitment=False, key_encipherment=True, data_encipherment=True, key_agreement=True, key_cert_sign=True, crl_sign=False, encipher_only=False, decipher_only=False),
-            critical=True)
-        builder2 = builder2.add_extension(
-            x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH]),
-            critical=True)
-        admin_certificate = builder2.sign(
-            private_key=ca_private_key, algorithm=hashes.SHA256(), backend=backends.default_backend()
-        )
-        admin_private_bytes = admin_private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.BestAvailableEncryption(str.encode(nifi_secret['Parameter']['Value'])))
-        admin_public_bytes = admin_certificate.public_bytes(
-            encoding=serialization.Encoding.PEM)
+            # Local directories and file names
+            os.makedirs(
+                "/tmp/nifi/certificates/" + identities[identity].get("name"),
+                exist_ok=True,
+            )
 
-        # ADMIN PKCS12
-        admin_p12 = pkcs12.serialize_key_and_certificates(
-            b"admin",
-            admin_private_key,
-            admin_certificate,
-            None,
-            serialization.BestAvailableEncryption(str.encode(nifi_secret['Parameter']['Value']))
-        )
+            keyfilename = (
+                "/tmp/nifi/certificates/"
+                + identities[identity].get("name")
+                + "/"
+                + identities[identity].get("name")
+                + ".key"
+            )
+            pemfilename = (
+                "/tmp/nifi/certificates/"
+                + identities[identity].get("name")
+                + "/"
+                + identities[identity].get("name")
+                + ".pem"
+            )
+            pkcs12filename = (
+                "/tmp/nifi/certificates/"
+                + identities[identity].get("name")
+                + "/"
+                + identities[identity].get("name")
+                + ".p12"
+            )
 
-        # UPLOAD
-        files = {
-            'nifi/certificates/ca/ca.pem': io.BytesIO(ca_public_bytes),
-            'nifi/certificates/ca/ca.key': io.BytesIO(ca_private_bytes),
-            'nifi/certificates/admin/admin_cert.pem': io.BytesIO(admin_public_bytes),
-            'nifi/certificates/admin/private_key.key': io.BytesIO(admin_private_bytes),
-            'nifi/certificates/admin/keystore.p12': io.BytesIO(admin_p12)
-        }
+            # privatekey generation
+            identity_privatekey = gen_privatekey()
+            identities[identity]["privatekey"] = identity_privatekey
+
+            identity_privatebytes = gen_privatebytes(
+                identities[identity].get("privatekey"), secret
+            )
+
+            # privatekey write
+            identities[identity]["privatebytes"] = identity_privatebytes
+            with open(
+                os.open(keyfilename, os.O_CREAT | os.O_WRONLY, 0o600), "wb"
+            ) as file:
+                file.write(identities[identity]["privatebytes"])
+            print(keyfilename + " written")
+
+            # publickey from privatekey
+            identity_publickey = gen_publickey(identity_privatekey)
+            identities[identity]["publickey"] = identity_publickey
+            identity_publicbytes = gen_publicbytes(identity_publickey)
+            identities[identity]["publicbytes"] = identity_publicbytes
+
+            # ca-signed certificate
+            identity_certificate = gen_x509(
+                u"NIFI",
+                identities[identity].get("name"),
+                identities[identity].get("publickey"),
+                identities["ca"].get("name"),
+                identities["ca"].get("privatekey"),
+                identities[identity].get("is_ca"),
+                identities[identity].get("is_client"),
+                identities[identity].get("is_server"),
+            )
+            identities[identity]["certificate"] = identity_certificate
+
+            with open(
+                os.open(pemfilename, os.O_CREAT | os.O_WRONLY, 0o600), "wb"
+            ) as file:
+                file.write(
+                    identities[identity]["certificate"].public_bytes(
+                        serialization.Encoding.PEM
+                    )
+                )
+            print(pemfilename + " written")
+
+            # CERTIFICATE STORE (.p12)
+            identity_certstore = gen_certificatestore(
+                identities[identity].get("name"),
+                identities[identity].get("privatekey"),
+                identities[identity].get("certificate"),
+                identities["ca"].get("certificate"),
+                secret,
+            )
+            identities[identity]["certstore"] = identity_certstore
+
+            with open(
+                os.open(pkcs12filename, os.O_CREAT | os.O_WRONLY, 0o600), "wb"
+            ) as file:
+                file.write(identities[identity]["certstore"])
+            print(pkcs12filename + " written")
+
+            # UPLOAD
+            files = {
+                "nifi/certificates/ca/ca.pem": io.BytesIO(
+                    identities["ca"].get("public_bytes")
+                ),
+                "nifi/certificates/ca/ca.key": io.BytesIO(
+                    identities["ca"].get("private_bytes")
+                ),
+                "nifi/certificates/admin/admin_cert.pem": io.BytesIO(
+                    identities["admin"].get("public_bytes")
+                ),
+                "nifi/certificates/admin/private_key.key": io.BytesIO(
+                    identities["admin"].get("private_bytes")
+                ),
+                "nifi/certificates/admin/keystore.p12": io.BytesIO(
+                    identities["admin"].get("identity_certstore")
+                ),
+            }
         for key in files:
             s3.meta.client.upload_fileobj(
                 files[key],
-                os.environ['BUCKET'],
+                os.environ["BUCKET"],
                 key,
-                ExtraArgs={'ServerSideEncryption':'aws:kms','SSEKMSKeyId':os.environ['KEY']})
-            print(key + ' put to s3.')
+                ExtraArgs={
+                    "ServerSideEncryption": "aws:kms",
+                    "SSEKMSKeyId": os.environ["KEY"],
+                },
+            )
+            print({"s3_upload": key, "msg": json.dumps("Complete")})
 
-    return {
-        'statusCode': 200,
-        'body': json.dumps('Complete')
-    }
+    return {"statusCode": 200, "body": json.dumps("Complete")}

--- a/zks-on-ec2/nifi-lambda-certs.tf
+++ b/zks-on-ec2/nifi-lambda-certs.tf
@@ -1,10 +1,6 @@
-data "local_file" "tf-nifi-lambda-certs-archive" {
-  filename = "nifi-lambda-certs.zip"
-}
-
 resource "aws_lambda_function" "tf-nifi-lambda-certs-function" {
   filename         = "nifi-lambda-certs.zip"
-  source_code_hash = data.local_file.tf-nifi-lambda-certs-archive.content_base64
+  source_code_hash = filebase64sha256("nifi-lambda-certs.zip")
   function_name    = "${var.name_prefix}-lambda-certs-${random_string.tf-nifi-random.result}"
   role             = aws_iam_role.tf-nifi-iam-role-lambda-certs.arn
   kms_key_arn      = aws_kms_key.tf-nifi-kmscmk-lambda.arn

--- a/zks-on-ec2/nifi-lambda-certs.tf
+++ b/zks-on-ec2/nifi-lambda-certs.tf
@@ -1,12 +1,10 @@
-data "archive_file" "tf-nifi-lambda-certs-archive" {
-  type        = "zip"
-  source_dir  = "nifi-lambda-certs"
-  output_path = "nifi-lambda-certs.zip"
+data "local_file" "tf-nifi-lambda-certs-archive" {
+  filename = "nifi-lambda-certs.zip"
 }
 
 resource "aws_lambda_function" "tf-nifi-lambda-certs-function" {
   filename         = "nifi-lambda-certs.zip"
-  source_code_hash = data.archive_file.tf-nifi-lambda-certs-archive.output_base64sha256
+  source_code_hash = data.local_file.tf-nifi-lambda-certs-archive.content_base64
   function_name    = "${var.name_prefix}-lambda-certs-${random_string.tf-nifi-random.result}"
   role             = aws_iam_role.tf-nifi-iam-role-lambda-certs.arn
   kms_key_arn      = aws_kms_key.tf-nifi-kmscmk-lambda.arn

--- a/zks-on-ec2/nifi-lambda-health.tf
+++ b/zks-on-ec2/nifi-lambda-health.tf
@@ -19,6 +19,7 @@ resource "aws_lambda_function" "tf-nifi-lambda-health-function" {
       WEB_PORT = var.web_port
       PREFIX   = var.name_prefix
       SUFFIX   = random_string.tf-nifi-random.result
+      REGION   = var.aws_region
     }
   }
   vpc_config {

--- a/zks-on-ec2/nifi-s3.tf
+++ b/zks-on-ec2/nifi-s3.tf
@@ -1,128 +1,42 @@
-# s3 bucket
+# bucket
 resource "aws_s3_bucket" "tf-nifi-bucket" {
-  bucket = "${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}"
-  acl    = "private"
-  versioning {
-    enabled = true
-  }
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.tf-nifi-kmscmk-s3.arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
+  bucket        = "${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}"
   force_destroy = true
-  policy        = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "KMS Manager",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": ["${data.aws_iam_user.tf-nifi-kmsmanager.arn}"]
-      },
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": [
-        "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}",
-        "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/*"
-      ]
-    },
-    {
-      "Sid": "Instance Lambda getnifi Lambda certs List",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": ["${aws_iam_role.tf-nifi-instance-iam-role.arn}","arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-getnifi-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-getnifi-${random_string.tf-nifi-random.result}","arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-certs-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-certs-${random_string.tf-nifi-random.result}"]
-      },
-      "Action": [
-        "s3:ListBucket",
-        "s3:ListBucketMultipartUploads"
-      ],
-      "Resource": ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}","arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/*"]
-    },
-    {
-      "Sid": "Instance Get",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": ["${aws_iam_role.tf-nifi-instance-iam-role.arn}"]
-      },
-      "Action": [
-        "s3:GetObject",
-        "s3:GetObjectVersion"
-      ],
-      "Resource": ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/*"]
-    },
-    {
-      "Sid": "Instance Put",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": ["${aws_iam_role.tf-nifi-instance-iam-role.arn}"]
-      },
-      "Action": [
-        "s3:PutObject",
-        "s3:PutObjectAcl"
-      ],
-      "Resource": [
-        "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/*",
-        "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/ssm/*"
-      ]
-    },
-    {
-      "Sid": "Lambda getnifi Put",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-getnifi-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-getnifi-${random_string.tf-nifi-random.result}"]
-      },
-      "Action": [
-        "s3:PutObject",
-        "s3:PutObjectAcl",
-        "s3:AbortMultipartUpload"
-      ],
-      "Resource": [
-        "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/downloads/*"
-      ]
-    },
-    {
-      "Sid": "Lambda certs Put",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-certs-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-certs-${random_string.tf-nifi-random.result}"]
-      },
-      "Action": [
-        "s3:PutObject",
-        "s3:PutObjectAcl",
-        "s3:AbortMultipartUpload"
-      ],
-      "Resource": [
-        "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/certificates/*"
-      ]
-    },
-    {
-      "Sid": "Lambda health Get",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-health-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-health-${random_string.tf-nifi-random.result}"]
-      },
-      "Action": [
-        "s3:GetObject",
-        "s3:GetObjectAcl"
-      ],
-      "Resource": [
-        "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/certificates/admin/admin_cert.pem",
-        "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/certificates/admin/private_key.key"
-      ]
-    }
-  ]
-}
-POLICY
 }
 
-# s3 block all public access to bucket
-resource "aws_s3_bucket_public_access_block" "tf-nifi-bucket-pubaccessblock" {
+# acl
+resource "aws_s3_bucket_acl" "tf-nifi-bucket" {
+  bucket = aws_s3_bucket.tf-nifi-bucket.id
+  acl    = "private"
+}
+
+# versioning
+resource "aws_s3_bucket_versioning" "tf-nifi-bucket" {
+  bucket = aws_s3_bucket.tf-nifi-bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf-nifi-bucket" {
+  bucket = aws_s3_bucket.tf-nifi-bucket.id
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.tf-nifi-kmscmk-s3.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+# access policy
+resource "aws_s3_bucket_policy" "tf-nifi-bucket" {
+  bucket = aws_s3_bucket.tf-nifi-bucket.id
+  policy = data.aws_iam_policy_document.tf-nifi-bucket.json
+}
+
+# public access policy
+resource "aws_s3_bucket_public_access_block" "tf-nifi-bucket" {
   bucket                  = aws_s3_bucket.tf-nifi-bucket.id
   block_public_acls       = true
   block_public_policy     = true
@@ -130,8 +44,120 @@ resource "aws_s3_bucket_public_access_block" "tf-nifi-bucket-pubaccessblock" {
   restrict_public_buckets = true
 }
 
+# policy
+data "aws_iam_policy_document" "tf-nifi-bucket" {
+  statement {
+    sid     = "KMS Manager"
+    effect  = "Allow"
+    actions = ["s3:*"]
+    resources = ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}",
+      "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/*"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_user.tf-nifi-kmsmanager.arn]
+    }
+  }
+  statement {
+    sid    = "Instance Lambda getnifi Lambda certs List"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads"
+    ]
+    resources = ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}", "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/*"]
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.tf-nifi-instance-iam-role.arn, "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-getnifi-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-getnifi-${random_string.tf-nifi-random.result}", "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-certs-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-certs-${random_string.tf-nifi-random.result}"]
+    }
+  }
+
+  statement {
+    sid    = "Instance Get"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion"
+    ]
+    resources = ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}", "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/*"]
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.tf-nifi-instance-iam-role.arn]
+    }
+  }
+
+  statement {
+    sid    = "Instance Put"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = [
+      "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/*",
+      "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/ssm/*"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.tf-nifi-instance-iam-role.arn]
+    }
+  }
+
+  statement {
+    sid    = "Lambda getnifi Put"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:AbortMultipartUpload"
+    ]
+    resources = [
+      "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/downloads/*"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-getnifi-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-getnifi-${random_string.tf-nifi-random.result}"]
+    }
+  }
+
+  statement {
+    sid    = "Lambda certs Put"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:AbortMultipartUpload"
+    ]
+    resources = [
+      "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/certificates/*"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-certs-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-certs-${random_string.tf-nifi-random.result}"]
+    }
+  }
+
+  statement {
+    sid    = "Lambda health Get"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAcl"
+    ]
+    resources = [
+      "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/certificates/admin/admin_cert.pem",
+      "arn:${data.aws_partition.tf-nifi-aws-partition.partition}:s3:::${var.name_prefix}-bucket-${random_string.tf-nifi-random.result}/nifi/certificates/admin/private_key.key"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.tf-nifi-aws-partition.partition}:sts::${data.aws_caller_identity.tf-nifi-aws-account.account_id}:assumed-role/${var.name_prefix}-iam-role-lambda-health-${random_string.tf-nifi-random.result}/${var.name_prefix}-lambda-health-${random_string.tf-nifi-random.result}"]
+    }
+  }
+
+}
+
 # s3 objects (zookeeper playbook)
-resource "aws_s3_bucket_object" "tf-nifi-zookeepers-files" {
+resource "aws_s3_object" "tf-nifi-zookeepers-files" {
   for_each       = fileset("playbooks/zookeepers/", "*")
   bucket         = aws_s3_bucket.tf-nifi-bucket.id
   key            = "nifi/zookeepers/${each.value}"
@@ -140,7 +166,7 @@ resource "aws_s3_bucket_object" "tf-nifi-zookeepers-files" {
 }
 
 # s3 objects (nodes playbook)
-resource "aws_s3_bucket_object" "tf-nifi-nodes-files" {
+resource "aws_s3_object" "tf-nifi-nodes-files" {
   for_each       = fileset("playbooks/nodes/", "*")
   bucket         = aws_s3_bucket.tf-nifi-bucket.id
   key            = "nifi/nodes/${each.value}"

--- a/zks-on-ec2/nifi-scaling-nodes.tf
+++ b/zks-on-ec2/nifi-scaling-nodes.tf
@@ -29,6 +29,9 @@ resource "aws_launch_configuration" "tf-nifi-launchconf" {
   }
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      image_id
+    ]
   }
   user_data = <<EOF
 #!/bin/bash

--- a/zks-on-ec2/nifi-scaling-nodes.tf
+++ b/zks-on-ec2/nifi-scaling-nodes.tf
@@ -17,7 +17,7 @@ locals {
 # launch conf
 resource "aws_launch_configuration" "tf-nifi-launchconf" {
   name_prefix          = "${var.name_prefix}-lconf-${random_string.tf-nifi-random.result}-"
-  image_id             = aws_ami_copy.tf-nifi-encrypted-ami.id
+  image_id             = data.aws_ami.tf-nifi-vendor-ami-latest.id
   instance_type        = var.instance_type
   key_name             = aws_key_pair.tf-nifi-instance-key.key_name
   iam_instance_profile = aws_iam_instance_profile.tf-nifi-instance-profile.name

--- a/zks-on-ec2/nifi-scaling-zks.tf
+++ b/zks-on-ec2/nifi-scaling-zks.tf
@@ -41,7 +41,7 @@ locals {
 # zk1 launchconf and asg
 resource "aws_launch_configuration" "tf-nifi-zk1-launchconf" {
   name_prefix          = "${var.name_prefix}-zk1lconf-${random_string.tf-nifi-random.result}-"
-  image_id             = aws_ami_copy.tf-nifi-encrypted-ami.id
+  image_id             = data.aws_ami.tf-nifi-vendor-ami-latest.id
   instance_type        = var.instance_type
   key_name             = aws_key_pair.tf-nifi-instance-key.key_name
   iam_instance_profile = aws_iam_instance_profile.tf-nifi-instance-profile.name
@@ -91,7 +91,7 @@ resource "aws_autoscaling_group" "tf-nifi-zk1-autoscalegroup" {
 # zk2 launchconf and asg
 resource "aws_launch_configuration" "tf-nifi-zk2-launchconf" {
   name_prefix          = "${var.name_prefix}-zk2lconf-${random_string.tf-nifi-random.result}-"
-  image_id             = aws_ami_copy.tf-nifi-encrypted-ami.id
+  image_id             = data.aws_ami.tf-nifi-vendor-ami-latest.id
   instance_type        = var.instance_type
   key_name             = aws_key_pair.tf-nifi-instance-key.key_name
   iam_instance_profile = aws_iam_instance_profile.tf-nifi-instance-profile.name
@@ -141,7 +141,7 @@ resource "aws_autoscaling_group" "tf-nifi-zk2-autoscalegroup" {
 # zk3 launchconf and asg
 resource "aws_launch_configuration" "tf-nifi-zk3-launchconf" {
   name_prefix          = "${var.name_prefix}-zk3lconf-${random_string.tf-nifi-random.result}-"
-  image_id             = aws_ami_copy.tf-nifi-encrypted-ami.id
+  image_id             = data.aws_ami.tf-nifi-vendor-ami-latest.id
   instance_type        = var.instance_type
   key_name             = aws_key_pair.tf-nifi-instance-key.key_name
   iam_instance_profile = aws_iam_instance_profile.tf-nifi-instance-profile.name

--- a/zks-on-ec2/nifi-scaling-zks.tf
+++ b/zks-on-ec2/nifi-scaling-zks.tf
@@ -53,6 +53,9 @@ resource "aws_launch_configuration" "tf-nifi-zk1-launchconf" {
   }
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      image_id
+    ]
   }
   user_data = <<EOF
 #!/bin/bash
@@ -103,6 +106,9 @@ resource "aws_launch_configuration" "tf-nifi-zk2-launchconf" {
   }
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      image_id
+    ]
   }
   user_data = <<EOF
 #!/bin/bash
@@ -153,6 +159,9 @@ resource "aws_launch_configuration" "tf-nifi-zk3-launchconf" {
   }
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      image_id
+    ]
   }
   user_data = <<EOF
 #!/bin/bash

--- a/zks-on-ec2/nifi-ssm.tf
+++ b/zks-on-ec2/nifi-ssm.tf
@@ -111,7 +111,7 @@ resource "aws_ssm_association" "tf-nifi-zookeepers-ssm-assoc" {
     SourceType     = "S3"
     Verbose        = "-v"
   }
-  depends_on = [aws_iam_role_policy_attachment.tf-nifi-iam-attach-ssm, aws_iam_role_policy_attachment.tf-nifi-iam-attach-s3, aws_s3_bucket_object.tf-nifi-zookeepers-files]
+  depends_on = [aws_iam_role_policy_attachment.tf-nifi-iam-attach-ssm, aws_iam_role_policy_attachment.tf-nifi-iam-attach-s3, aws_s3_object.tf-nifi-zookeepers-files]
 }
 
 # nodes
@@ -133,5 +133,5 @@ resource "aws_ssm_association" "tf-nifi-nodes-ssm-assoc" {
     SourceType     = "S3"
     Verbose        = "-v"
   }
-  depends_on = [aws_iam_role_policy_attachment.tf-nifi-iam-attach-ssm, aws_iam_role_policy_attachment.tf-nifi-iam-attach-s3, aws_s3_bucket_object.tf-nifi-nodes-files]
+  depends_on = [aws_iam_role_policy_attachment.tf-nifi-iam-attach-ssm, aws_iam_role_policy_attachment.tf-nifi-iam-attach-s3, aws_s3_object.tf-nifi-nodes-files]
 }

--- a/zks-on-ec2/nifi.tfvars
+++ b/zks-on-ec2/nifi.tfvars
@@ -6,7 +6,7 @@ aws_region  = "us-east-1"
 kms_manager = "some_iam_user"
 
 # password for keys and keystores
-nifi_secret = "changeme"
+nifi_secret = "change_me"
 
 # additional aws tags
 aws_default_tags = {
@@ -16,23 +16,26 @@ aws_default_tags = {
 # the subnet(s) permitted to browse nifi (port 2170 or web_port) via the AWS NLB
 mgmt_cidrs = ["127.0.0.0/32"]
 
-# the subnet(s) permitted to send traffic to service ports
-client_cidrs = []
-
 # management port for HTTPS (and inter-cluster communication) via mgmt NLB
 web_port = 2170
 
+# the subnet(s) permitted to send traffic to service ports
+# e.g. ["1.2.3.4/32", "1.1.1.1/31"]
+client_cidrs = []
+
 # service ports for traffic inbound via service NLB
-tcp_service_ports    = [2200, 2201]
+# e.g. [2222, 2223]
+tcp_service_ports    = []
 udp_service_ports    = []
 tcpudp_service_ports = []
 
 # inter-cluster communication occurs on ports web_port and 2171 through 2176
 
 # public ssh key
-instance_key = "ssh-rsa AAAAB3NzaD2yc2EAAAADAQABAAABAQCNsxnMWfrG3SoLr4uJMavf43YkM5wCbdO7X5uBvRU8oh1W+A/Nd/jie2tc3UpwDZwS3w6MAfnu8B1gE9lzcgTu1FFf0us5zIWYR/mSoOFKlTiaI7Uaqkc+YzmVw/fy1iFxDDeaZfoc0vuQvPr+LsxUL5UY4ko4tynCSp7zgVpot/OppqdHl5J+DYhNubm8ess6cugTustUZoDmJdo2ANQENeBUNkBPXUnMO1iulfNb6GnwWJ0Z5TRRLGSu2gya2wMLeo1rBJ5cbZZgVLMVHiKgwBy/svUQreR8R+fpVW+Q4rx6sPAltLaOUONn0SF2BvvJUueqxpAIaA2rU4MS420P"
+instance_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCNsxnMWfrG3SoLr4uJMavf43YkM5wCbdO7X5uBvRU8oh1W+A/Nd/jie2tc3UpwDZwS3w6MAfnu8B1gE9lzcgTu1FFf0us5zIWYR/mSoOFKlTiaI7Uaqkc+YzmVw/fy1iFxDDeaZfoc0vuQvPr+LsxUL5UY4ko4tynCSp7zgVpot/OppqdHl5J+DYhNubm8ess6cugTustUZoDmJdo2ANQENeBUNkBPXUnMO1iulfNb6GnwWJ0Z5TRRLGSu1gya2wMLeo1rBJFcb6ZgVLMVHiKgwBy/svUQreR8R+fpVW+Q4rx6RSAltLROUONn0SF2BvvJUueqxpAIaA2rU4MSI69P"
 
-# size according to workloads, must be x86 based with at least 2GB of RAM (which is barely enough).
+# size according to workloads, probably stick with x86-based, though arm may work.
+# also nifi should have 2GB+ of RAM (which is barely enough).
 instance_type = "r5.large"
 
 # the root block size of the instances (in GiB)
@@ -41,7 +44,7 @@ instance_vol_size = 15
 # enable first/second/third zookeeper+nifi nodes (1 for yes, 0 for no)
 enable_zk1 = 1
 enable_zk2 = 1
-enable_zk3 = 0
+enable_zk3 = 1
 
 # the initial size (min) and max count of non-zookeeper nifi nodes.
 # scale is based on CPU load (see nifi-scaling-nodes.tf)
@@ -60,18 +63,18 @@ vendor_ami_name_string    = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-serv
 log_retention_days = 30
 
 # health check frequency - if an instance fails a health check it is terminated and replaced
-health_check_enable = true
+health_check_enable = false
 health_check_unit   = "minutes"
 health_check_count  = 10
 
 # nifi/nifi-toolkit and zookeeper versions downloaded from urls below
-nifi_version = "1.14.0"
-zk_version   = "3.7.0"
+nifi_version = "1.16.3"
+zk_version   = "3.8.0"
 
 # urls for a lambda function to fetch zookeeper, nifi, and nifi toolkit and put to s3
-zk_url      = "https://apache.osuosl.org/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0-bin.tar.gz"
-nifi_url    = "https://apache.osuosl.org/nifi/1.14.0/nifi-1.14.0-bin.tar.gz"
-toolkit_url = "https://apache.osuosl.org/nifi/1.14.0/nifi-toolkit-1.14.0-bin.tar.gz"
+zk_url      = "https://archive.apache.org/dist/zookeeper/zookeeper-3.8.0/apache-zookeeper-3.8.0-bin.tar.gz"
+nifi_url    = "https://archive.apache.org/dist/nifi/1.16.3/nifi-1.16.3-bin.tar.gz"
+toolkit_url = "https://archive.apache.org/dist/nifi/1.16.3/nifi-toolkit-1.16.3-bin.tar.gz"
 
 # vpc specific vars, modify these values if there would be overlap with existing resources.
 vpc_cidr     = "10.10.10.0/24"


### PR DESCRIPTION
* nifi-lambda-certs
  * .py more readable with functions
  * pre-packaged to include python 3.8 cryptography libs/bins
* nifi-lambda-health
  * use cert during health check
* ami
  * now a direct reference to the latest vendored ubuntu 20.02 ami
  * asgs ignore_changes on ami id if ami updates
* s3 bucket split into separate resources to avoid deprecation
